### PR TITLE
[iOS] Do not pass exception instance to rejecter

### DIFF
--- a/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
+++ b/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
@@ -54,7 +54,7 @@ RCT_EXPORT_METHOD(
         cookie = [self makeHTTPCookieObject:url props:props];
     }
     @catch ( NSException *e ) {
-        reject(@"", [e reason], e);
+        reject(@"", [e reason], nil);
         return;
     }
 


### PR DESCRIPTION
Do not know why exactly it can't get access to localized description, but from JS perspective exception instance not needed.

This fix will make these errors much more specific AND this error will be catchable on JS side:

https://github.com/react-native-cookies/cookies/issues/103
https://github.com/react-native-cookies/cookies/issues/59
https://github.com/react-native-cookies/cookies/issues/56
