### PR TITLE
fix(iOS): fix 'secure' and 'httpOnly' values always being false

### DIFF
--- a/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
+++ b/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
@@ -313,11 +313,11 @@ RCT_EXPORT_METHOD(
     if (!isEmpty(expires)) {
          [cookieProperties setObject:expires forKey:NSHTTPCookieExpires];
     }
-    if (!isEmpty(secure)) {
-        [cookieProperties setObject:secure forKey:@"secure"];
+    if ([secure boolValue]) {
+        [cookieProperties setObject:secure forKey:NSHTTPCookieSecure];
     }
-    if (!isEmpty(httpOnly)) {
-        [cookieProperties setObject:httpOnly forKey:@"HTTPOnly"];
+    if ([httpOnly boolValue]) {
+        [cookieProperties setObject:httpOnly forKey:@"HttpOnly"];
     }
 
     NSHTTPCookie *cookie = [NSHTTPCookie cookieWithProperties:cookieProperties];


### PR DESCRIPTION
# Summary
On iOS `set()` method always stores cookies with `secure` and `httpOnly` being `false`. This PR fixes it.
Possibly a breaking change for those, who **assume** they have been storing `secure` and `httpOnly` cookies.

Fixes #38 

_Note: this is my first community PR ever. :innocent:_

## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in README.md
- [ ] I mentioned this change in CHANGELOG.md
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (example/App.js)
