### PR TITLE
fix: change iOS react header import style to work with Expo SDK

### DIFF
--- a/ios/RNCookieManagerIOS/RNCookieManagerIOS.h
+++ b/ios/RNCookieManagerIOS/RNCookieManagerIOS.h
@@ -5,11 +5,7 @@
   * LICENSE file here: https://github.com/joeferraro/react-native-cookies/blob/master/LICENSE.md.		
   */
 
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
 #import <React/RCTBridgeModule.h>
-#endif
 
 #import <WebKit/WebKit.h>
 

--- a/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
+++ b/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
@@ -6,11 +6,7 @@
   */
 
 #import "RNCookieManagerIOS.h"
-#if __has_include("RCTConvert.h")
-#import "RCTConvert.h"
-#else
 #import <React/RCTConvert.h>
-#endif
 
 static NSString * const NOT_AVAILABLE_ERROR_MESSAGE = @"WebKit/WebKit-Components are only available with iOS11 and higher!";
 static NSString * const INVALID_URL_MISSING_HTTP = @"Invalid URL: It may be missing a protocol (ex. http:// or https://).";


### PR DESCRIPTION
Expo 44.0 now requires importing RN headers using `#import <React/*.h>` form, see https://github.com/expo/expo/issues/15622#issuecomment-997141629 . Old import style will cause the following build errors.

```

Showing Recent Messages
CompileC /Users/abing/Library/Developer/Xcode/DerivedData/GcoresMobile-gakxkwdaeaesajbslhafuviqcirt/Build/Intermediates.noindex/Pods.build/Debug-iphoneos/react-native-cookies.build/Objects-normal/arm64/RNCookieManagerIOS.o /Users/abing/Code/gcores/gcores-mobile/node_modules/@react-native-cookies/cookies/ios/RNCookieManagerIOS/RNCookieManagerIOS.m normal arm64 objective-c com.apple.compilers.llvm.clang.1_0.compiler (in target 'react-native-cookies' from project 'Pods')
    cd /Users/abing/Code/gcores/gcores-mobile/ios/Pods
    export LANG\=en_US.US-ASCII
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -x objective-c -target arm64-apple-ios11.0 -fmessage-length\=0 -fdiagnostics-show-note-include-stack -fmacro-backtrace-limit\=0 -std\=gnu11 -fobjc-arc -fobjc-weak -fmodules -fmodules-cache-path\=/Users/abing/Library/Developer/Xcode/DerivedData/ModuleCache.noindex -fmodules-prune-interval\=86400 -fmodules-prune-after\=345600 -fbuild-session-file\=/Users/abing/Library/Developer/Xcode/DerivedData/ModuleCache.noindex/Session.modulevalidation -fmodules-validate-once-per-build-session -Wnon-modular-include-in-framework-module -Werror\=non-modular-include-in-framework-module -Wno-trigraphs -fpascal-strings -O0 -fno-common -Wno-missing-field-initializers -Wno-missing-prototypes -Werror\=return-type -Wdocumentation -Wunreachable-code -Wno-implicit-atomic-properties -Werror\=deprecated-objc-isa-usage -Wno-objc-interface-ivars -Werror\=objc-root-class -Wno-arc-repeated-use-of-weak -Wimplicit-retain-self -Wduplicate-method-match -Wno-missing-braces -Wparentheses -Wswitch -Wunused-function -Wno-unused-label -Wno-unused-parameter -Wunused-variable -Wunused-value -Wempty-body -Wuninitialized -Wconditional-uninitialized -Wno-unknown-pragmas -Wno-shadow -Wno-four-char-constants -Wno-conversion -Wconstant-conversion -Wint-conversion -Wbool-conversion -Wenum-conversion -Wno-float-conversion -Wnon-literal-null-conversion -Wobjc-literal-conversion -Wshorten-64-to-32 -Wpointer-sign -Wno-newline-eof -Wno-selector -Wno-strict-selector-match -Wundeclared-selector -Wdeprecated-implementations -DPOD_CONFIGURATION_DEBUG\=1 -DDEBUG\=1 -DCOCOAPODS\=1 -DOBJC_OLD_DISPATCH_PROTOTYPES\=0 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS15.0.sdk -fstrict-aliasing -Wprotocol -Wdeprecated-declarations -g -Wno-sign-conversion -Winfinite-recursion -Wcomma -Wblock-capture-autoreleasing -Wstrict-prototypes -Wno-semicolon-before-method-body -Wunguarded-availability -fembed-bitcode-marker -index-store-path /Users/abing/Library/Developer/Xcode/DerivedData/GcoresMobile-gakxkwdaeaesajbslhafuviqcirt/Index/DataStore -iquote /Users/abing/Library/Developer/Xcode/DerivedData/GcoresMobile-gakxkwdaeaesajbslhafuviqcirt/Build/Intermediates.noindex/Pods.build/Debug-iphoneos/react-native-cookies.build/react-native-cookies-generated-files.hmap -I/Users/abing/Library/Developer/Xcode/DerivedData/GcoresMobile-gakxkwdaeaesajbslhafuviqcirt/Build/Intermediates.noindex/Pods.build/Debug-iphoneos/react-native-cookies.build/react-native-cookies-own-target-headers.hmap -I/Users/abing/Library/Developer/Xcode/DerivedData/GcoresMobile-gakxkwdaeaesajbslhafuviqcirt/Build/Intermediates.noindex/Pods.build/Debug-iphoneos/react-native-cookies.build/react-native-cookies-all-non-framework-target-headers.hmap -ivfsoverlay /Users/abing/Library/Developer/Xcode/DerivedData/GcoresMobile-gakxkwdaeaesajbslhafuviqcirt/Build/Intermediates.noindex/Pods.build/Debug-iphoneos/react-native-cookies.build/all-product-headers.yaml -iquote /Users/abing/Library/Developer/Xcode/DerivedData/GcoresMobile-gakxkwdaeaesajbslhafuviqcirt/Build/Intermediates.noindex/Pods.build/Debug-iphoneos/react-native-cookies.build/react-native-cookies-project-headers.hmap -I/Users/abing/Library/Developer/Xcode/DerivedData/GcoresMobile-gakxkwdaeaesajbslhafuviqcirt/Build/Products/Debug-iphoneos/react-native-cookies/include -I/Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Private -I/Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Private/react-native-cookies -I/Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public -I/Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/DoubleConversion -I/Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/RCT-Folly -I/Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/React-Core -I/Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/React-callinvoker -I/Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/React-cxxreact -I/Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/React-jsi -I/Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/React-jsiexecutor -I/Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/React-jsinspector -I/Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/React-logger -I/Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/React-perflogger -I/Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/React-runtimeexecutor -I/Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/Yoga -I/Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/fmt -I/Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/glog -I/Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/libevent -I/Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/react-native-cookies -I/Users/abing/Library/Developer/Xcode/DerivedData/GcoresMobile-gakxkwdaeaesajbslhafuviqcirt/Build/Intermediates.noindex/Pods.build/Debug-iphoneos/react-native-cookies.build/DerivedSources-normal/arm64 -I/Users/abing/Library/Developer/Xcode/DerivedData/GcoresMobile-gakxkwdaeaesajbslhafuviqcirt/Build/Intermediates.noindex/Pods.build/Debug-iphoneos/react-native-cookies.build/DerivedSources/arm64 -I/Users/abing/Library/Developer/Xcode/DerivedData/GcoresMobile-gakxkwdaeaesajbslhafuviqcirt/Build/Intermediates.noindex/Pods.build/Debug-iphoneos/react-native-cookies.build/DerivedSources -F/Users/abing/Library/Developer/Xcode/DerivedData/GcoresMobile-gakxkwdaeaesajbslhafuviqcirt/Build/Products/Debug-iphoneos/react-native-cookies -fmodule-map-file\=/Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Private/React/React-Core.modulemap -fmodule-map-file\=/Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/yoga/Yoga.modulemap -include /Users/abing/Code/gcores/gcores-mobile/ios/Pods/Target\ Support\ Files/react-native-cookies/react-native-cookies-prefix.pch -MMD -MT dependencies -MF /Users/abing/Library/Developer/Xcode/DerivedData/GcoresMobile-gakxkwdaeaesajbslhafuviqcirt/Build/Intermediates.noindex/Pods.build/Debug-iphoneos/react-native-cookies.build/Objects-normal/arm64/RNCookieManagerIOS.d --serialize-diagnostics /Users/abing/Library/Developer/Xcode/DerivedData/GcoresMobile-gakxkwdaeaesajbslhafuviqcirt/Build/Intermediates.noindex/Pods.build/Debug-iphoneos/react-native-cookies.build/Objects-normal/arm64/RNCookieManagerIOS.dia -c /Users/abing/Code/gcores/gcores-mobile/node_modules/@react-native-cookies/cookies/ios/RNCookieManagerIOS/RNCookieManagerIOS.m -o /Users/abing/Library/Developer/Xcode/DerivedData/GcoresMobile-gakxkwdaeaesajbslhafuviqcirt/Build/Intermediates.noindex/Pods.build/Debug-iphoneos/react-native-cookies.build/Objects-normal/arm64/RNCookieManagerIOS.o

In file included from /Users/abing/Code/gcores/gcores-mobile/node_modules/@react-native-cookies/cookies/ios/RNCookieManagerIOS/RNCookieManagerIOS.m:8:
In file included from /Users/abing/Code/gcores/gcores-mobile/node_modules/@react-native-cookies/cookies/ios/RNCookieManagerIOS/RNCookieManagerIOS.h:9:
/Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/React-Core/React/RCTBridgeModule.h:68:11: warning: duplicate protocol definition of 'RCTBridgeModule' is ignored [-Wduplicate-protocol]
@protocol RCTBridgeModule <NSObject>
          ^
In module 'React' imported from /Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/React-Core/React/RCTBridgeModule.h:11:
/Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/React-Core/React/RCTBridgeModule.h:68:11: note: previous definition is here
@protocol RCTBridgeModule <NSObject>
          ^
In file included from /Users/abing/Code/gcores/gcores-mobile/node_modules/@react-native-cookies/cookies/ios/RNCookieManagerIOS/RNCookieManagerIOS.m:8:
In file included from /Users/abing/Code/gcores/gcores-mobile/node_modules/@react-native-cookies/cookies/ios/RNCookieManagerIOS/RNCookieManagerIOS.h:9:
/Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/React-Core/React/RCTBridgeModule.h:394:11: warning: duplicate protocol definition of 'RCTTurboModuleRegistry' is ignored [-Wduplicate-protocol]
@protocol RCTTurboModuleRegistry <NSObject>
          ^
In module 'React' imported from /Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/React-Core/React/RCTBridgeModule.h:11:
/Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/React-Core/React/RCTBridgeModule.h:394:11: note: previous definition is here
@protocol RCTTurboModuleRegistry <NSObject>
          ^
In file included from /Users/abing/Code/gcores/gcores-mobile/node_modules/@react-native-cookies/cookies/ios/RNCookieManagerIOS/RNCookieManagerIOS.m:8:
In file included from /Users/abing/Code/gcores/gcores-mobile/node_modules/@react-native-cookies/cookies/ios/RNCookieManagerIOS/RNCookieManagerIOS.h:9:
/Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/React-Core/React/RCTBridgeModule.h:424:1: error: duplicate interface definition for class 'RCTModuleRegistry'
@interface RCTModuleRegistry : NSObject
^
In module 'React' imported from /Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/React-Core/React/RCTBridgeModule.h:11:
/Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/React-Core/React/RCTBridgeModule.h:424:12: note: previous definition is here
@interface RCTModuleRegistry : NSObject
           ^
In file included from /Users/abing/Code/gcores/gcores-mobile/node_modules/@react-native-cookies/cookies/ios/RNCookieManagerIOS/RNCookieManagerIOS.m:8:
In file included from /Users/abing/Code/gcores/gcores-mobile/node_modules/@react-native-cookies/cookies/ios/RNCookieManagerIOS/RNCookieManagerIOS.h:9:
/Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/React-Core/React/RCTBridgeModule.h:438:1: error: duplicate interface definition for class 'RCTBundleManager'
@interface RCTBundleManager : NSObject
^
In module 'React' imported from /Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/React-Core/React/RCTBridgeModule.h:11:
/Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/React-Core/React/RCTBridgeModule.h:438:12: note: previous definition is here
@interface RCTBundleManager : NSObject
           ^
In file included from /Users/abing/Code/gcores/gcores-mobile/node_modules/@react-native-cookies/cookies/ios/RNCookieManagerIOS/RNCookieManagerIOS.m:8:
In file included from /Users/abing/Code/gcores/gcores-mobile/node_modules/@react-native-cookies/cookies/ios/RNCookieManagerIOS/RNCookieManagerIOS.h:9:
/Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/React-Core/React/RCTBridgeModule.h:444:18: error: property has a previous declaration
@property NSURL *bundleURL;
                 ^
In module 'React' imported from /Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/React-Core/React/RCTBridgeModule.h:11:
/Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/React-Core/React/RCTBridgeModule.h:444:18: note: property declared here
@property NSURL *bundleURL;
                 ^
In file included from /Users/abing/Code/gcores/gcores-mobile/node_modules/@react-native-cookies/cookies/ios/RNCookieManagerIOS/RNCookieManagerIOS.m:8:
In file included from /Users/abing/Code/gcores/gcores-mobile/node_modules/@react-native-cookies/cookies/ios/RNCookieManagerIOS/RNCookieManagerIOS.h:9:
/Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/React-Core/React/RCTBridgeModule.h:452:1: error: duplicate interface definition for class 'RCTViewRegistry'
@interface RCTViewRegistry : NSObject
^
In module 'React' imported from /Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/React-Core/React/RCTBridgeModule.h:11:
/Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/React-Core/React/RCTBridgeModule.h:452:12: note: previous definition is here
@interface RCTViewRegistry : NSObject
           ^
In file included from /Users/abing/Code/gcores/gcores-mobile/node_modules/@react-native-cookies/cookies/ios/RNCookieManagerIOS/RNCookieManagerIOS.m:8:
In file included from /Users/abing/Code/gcores/gcores-mobile/node_modules/@react-native-cookies/cookies/ios/RNCookieManagerIOS/RNCookieManagerIOS.h:9:
/Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/React-Core/React/RCTBridgeModule.h:469:1: error: duplicate interface definition for class 'RCTCallableJSModules'
@interface RCTCallableJSModules : NSObject
^
In module 'React' imported from /Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/React-Core/React/RCTBridgeModule.h:11:
/Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/React-Core/React/RCTBridgeModule.h:469:12: note: previous definition is here
@interface RCTCallableJSModules : NSObject
           ^
/Users/abing/Code/gcores/gcores-mobile/node_modules/@react-native-cookies/cookies/ios/RNCookieManagerIOS/RNCookieManagerIOS.m:94:22: warning: 'sendAsynchronousRequest:queue:completionHandler:' is deprecated: first deprecated in iOS 9.0 - Use [NSURLSession dataTaskWithRequest:completionHandler:] (see NSURLSession.h [-Wdeprecated-declarations]
    [NSURLConnection sendAsynchronousRequest:request  queue:[[NSOperationQueue alloc] init]
                     ^
In module 'Foundation' imported from /Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/React-Core/React/RCTBridgeModule.h:8:
/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS15.0.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSURLConnection.h:454:1: note: 'sendAsynchronousRequest:queue:completionHandler:' has been explicitly marked deprecated here
+ (void)sendAsynchronousRequest:(NSURLRequest*) request
^
/Users/abing/Code/gcores/gcores-mobile/node_modules/@react-native-cookies/cookies/ios/RNCookieManagerIOS/RNCookieManagerIOS.m:272:23: error: declaration of 'RCTConvert' must be imported from module 'React.RCTConvert' before it is required
    NSString *name = [RCTConvert NSString:props[@"name"]];
                      ^
In module 'React' imported from /Users/abing/Code/gcores/gcores-mobile/ios/Pods/Headers/Public/React-Core/React/RCTBridgeModule.h:11:
/Users/abing/Code/gcores/gcores-mobile/node_modules/react-native/React/Base/RCTConvert.h:27:12: note: declaration here is not visible
@interface RCTConvert : NSObject
           ^
3 warnings and 6 errors generated.


```