### PR TITLE
Implement Android's removeSessionCookies method

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,16 @@ CookieManager.flush()
   .then((success) => {
     console.log('CookieManager.flush =>', success);
   });
+
+// Remove session cookies (ANDROID ONLY)
+// Session cookies are cookies with no expires set. Android typically does not
+// remove these, it is up to the developer to decide when to remove them.
+// The return value is true if any session cookies were removed.
+// iOS handles removal of session cookies automatically on app open.
+CookieManager.removeSessionCookies()
+  .then((sessionCookiesRemoved) => {
+    console.log('CookieManager.removeSessionCookies =>', sessionCookiesRemoved);
+  });
 ```
 
 ### WebKit-Support (iOS only)

--- a/android/src/main/java/com/reactnativecommunity/cookies/CookieManagerModule.java
+++ b/android/src/main/java/com/reactnativecommunity/cookies/CookieManagerModule.java
@@ -103,6 +103,20 @@ public class CookieManagerModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void removeSessionCookies(Promise promise) {
+        try {
+            getCookieManager().removeSessionCookies(new ValueCallback<Boolean>() {
+                @Override
+                public void onReceiveValue(Boolean data) {
+                    promise.resolve(data);
+                }
+            });
+        } catch (Exception e) {
+            promise.reject(e);
+        }
+    }
+
+    @ReactMethod
     public void getFromResponse(String url, Promise promise) throws URISyntaxException, IOException {
         promise.resolve(url);
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,9 +23,11 @@ declare module '@react-native-cookies/cookies' {
 
     clearAll(useWebKit?: boolean): Promise<boolean>;
     
+    // Android only
     flush(): Promise<void>;
+    removeSessionCookies(): Promise<boolean>;
 
-    //iOS only
+    // iOS only
     getAll(useWebKit?: boolean): Promise<Cookies>;
     clearByName(
       url: string,

--- a/index.js
+++ b/index.js
@@ -46,6 +46,11 @@ module.exports = {
       await CookieManager.flush();
     }
   },
+  removeSessionCookies: async () => {
+    if (Platform.OS === 'android') {
+      return await CookieManager.removeSessionCookies();
+    }
+  },
 };
 
 for (var i = 0; i < functions.length; i++) {


### PR DESCRIPTION
# Description

I'm submitting a PR to implement the Android CookieManager removeSessionCookies method. Docs on what this does exactly are at the [Android CookieManager documentation](https://developer.android.com/reference/android/webkit/CookieManager#removeSessionCookies(android.webkit.ValueCallback%3Cjava.lang.Boolean%3E)). As a quick description, this lets developers remove all cookies that are session cookies. These are cookies with no Expires attribute.

We use Rails with the Devise gem to handle authentication. Rails sets a session cookie with no Expires attribute and a remember user cookie with a desired expiry. Currently, the session cookie will never be removed as per how Android operates so the remember period is effectively ignored on Android. So implementing this method will give RN developers a way of controlling whether they want to clear these out. As an example, we call this prior to checking with an API call if the user is still logged in during the startup of the app.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# How Has This Been Tested?

I have used MITMProxy with an Android API 30 emulator and a API 28 LG G6 phone to verify that session cookies can be removed prior to performing a `fetch` call in RN and it removes the session cookies from the next call correctly. This should also work for Android webviews as well.