### PR TITLE
[readme] Clarify Expo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,13 @@ This module was ported from [joeferraro/react-native-cookies](https://github.com
 
 ✅ iOS  
 ✅ Android  
-❌ Expo is working on their own cookie support (https://github.com/expo/expo/issues/6756)
 
 Currently lacking support for Windows, macOS, and web. Support for these platforms will be created when there is a need for them. Starts with a posted issue.
+
+## Expo
+
+✅ You can use this library with [Development Builds](https://docs.expo.dev/development/introduction/). No config plugin is required.
+❌ This library can't be used in the "Expo Go" app because it [requires custom native code](https://docs.expo.dev/workflow/customizing/).
 
 ## Installation
 


### PR DESCRIPTION
Now that you can do [development builds](https://docs.expo.dev/development/introduction/) with EAS Build or use `expo run:[ios|android]` locally to accomplish something similar, it seems worth clarifying how developers with Expo projects can take advantage of this useful library.

[We are trying to come up with some standard messaging](https://expo.notion.site/Documenting-Expo-support-in-READMEs-f250a20b4bd5472cab0757918cb21062) that we can include in READMEs popular react-native libraries so if think this is unclear or have some suggestions to improve it, let me know!